### PR TITLE
Add manual ChatClient configuration using Ollama and Spring AI

### DIFF
--- a/spring-ai/springai-chatclient-manual-config/pom.xml
+++ b/spring-ai/springai-chatclient-manual-config/pom.xml
@@ -1,0 +1,89 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.sample.app</groupId>
+	<artifactId>springai-chatclient-manual-config</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<properties>
+		<java.version>21</java.version>
+		<spring-ai.version>1.0.0</spring-ai.version>
+	</properties>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.4</version>
+		<relativePath /> <!-- lookup parent from repository -->
+	</parent>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-starter-model-ollama</artifactId>
+		</dependency>
+
+		<!-- OpenAPI/Swagger Documentation -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.6.0</version>
+		</dependency>
+
+	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-bom</artifactId>
+				<version>${spring-ai.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>2.44.5</version> <!-- Latest stable version as of June
+				2025 -->
+				<configuration>
+					<java>
+						<!-- Apply Google Java Format -->
+						<googleJavaFormat />
+
+						<!-- General formatting and cleanup -->
+						<trimTrailingWhitespace />
+						<endWithNewline />
+						<removeUnusedImports />
+					</java>
+				</configuration>
+
+				<executions>
+					<!-- Check formatting during 'verify' phase -->
+					<execution>
+						<id>spotless-check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<phase>verify</phase>
+					</execution>
+				</executions>
+			</plugin>
+
+
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-ai/springai-chatclient-manual-config/src/main/java/com/sample/app/App.java
+++ b/spring-ai/springai-chatclient-manual-config/src/main/java/com/sample/app/App.java
@@ -1,0 +1,12 @@
+package com.sample.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class App {
+
+  public static void main(String[] args) {
+    SpringApplication.run(App.class, args);
+  }
+}

--- a/spring-ai/springai-chatclient-manual-config/src/main/java/com/sample/app/config/ChatConfig.java
+++ b/spring-ai/springai-chatclient-manual-config/src/main/java/com/sample/app/config/ChatConfig.java
@@ -1,0 +1,27 @@
+package com.sample.app.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.ollama.OllamaChatModel;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.ai.ollama.api.OllamaOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatConfig {
+
+  @Bean
+  public ChatClient chatClient() {
+    // 1. Create the Ollama API client
+    OllamaApi ollamaApi = OllamaApi.builder().baseUrl("http://localhost:11434").build();
+
+    OllamaOptions defaultOptions =
+        OllamaOptions.builder().model("llama3.2").temperature(0.7).build();
+
+    // 2. Define the chat options
+    OllamaChatModel ollamaChatModel =
+        OllamaChatModel.builder().ollamaApi(ollamaApi).defaultOptions(defaultOptions).build();
+
+    return ChatClient.builder(ollamaChatModel).build();
+  }
+}

--- a/spring-ai/springai-chatclient-manual-config/src/main/java/com/sample/app/controller/ChatController.java
+++ b/spring-ai/springai-chatclient-manual-config/src/main/java/com/sample/app/controller/ChatController.java
@@ -1,0 +1,100 @@
+package com.sample.app.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chat")
+@Tag(name = "Chat API", description = "AI Chat endpoints using Llama 3.2")
+public class ChatController {
+
+  @Autowired private ChatClient chatClient;
+
+  @GetMapping
+  @Operation(
+      summary = "Send a chat message",
+      description = "Send a message to the AI and get a response")
+  public ResponseEntity<ChatResponse> chat(
+      @Parameter(description = "The message to send to the AI", example = "Hello, how are you?")
+          @RequestParam(defaultValue = "Hello")
+          String message) {
+    try {
+      String response = chatClient.prompt(message).call().content();
+      return ResponseEntity.ok(new ChatResponse(message, response));
+    } catch (Exception e) {
+      return ResponseEntity.internalServerError()
+          .body(new ChatResponse(message, "Error: " + e.getMessage()));
+    }
+  }
+
+  @PostMapping
+  @Operation(
+      summary = "Send a chat message via POST",
+      description = "Send a message to the AI via POST request")
+  public ResponseEntity<ChatResponse> chatPost(@RequestBody ChatRequest request) {
+    try {
+      String response = chatClient.prompt(request.getMessage()).call().content();
+      return ResponseEntity.ok(new ChatResponse(request.getMessage(), response));
+    } catch (Exception e) {
+      return ResponseEntity.internalServerError()
+          .body(new ChatResponse(request.getMessage(), "Error: " + e.getMessage()));
+    }
+  }
+
+  // DTO classes
+  public static class ChatRequest {
+    private String message;
+
+    public ChatRequest() {}
+
+    public ChatRequest(String message) {
+      this.message = message;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public void setMessage(String message) {
+      this.message = message;
+    }
+  }
+
+  public static class ChatResponse {
+    private String userMessage;
+    private String aiResponse;
+
+    public ChatResponse() {}
+
+    public ChatResponse(String userMessage, String aiResponse) {
+      this.userMessage = userMessage;
+      this.aiResponse = aiResponse;
+    }
+
+    public String getUserMessage() {
+      return userMessage;
+    }
+
+    public void setUserMessage(String userMessage) {
+      this.userMessage = userMessage;
+    }
+
+    public String getAiResponse() {
+      return aiResponse;
+    }
+
+    public void setAiResponse(String aiResponse) {
+      this.aiResponse = aiResponse;
+    }
+  }
+}


### PR DESCRIPTION
- Added a @Configuration class to programmatically define a ChatClient bean.
- Integrated Ollama API with custom base URL pointing to localhost:11434.
- Configured model options (e.g., model name: llama3, temperature: 0.7).
- Built and exposed ChatClient using OllamaChatModel.
- Useful for use cases where auto-configuration is not preferred or local LLMs are used.
